### PR TITLE
Update Message type to reflect increased message size for PQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Optimize stack usage of `Dispatch::poll`
 
 ## [0.1.1] - 2022-08-22
 - adjust to `interchange` API change

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ pub enum Error {
 
 // TODO: find reasonable size
 // pub type Message = heapless::Vec<u8, 3072>;
-pub type Message = heapless::Vec<u8, 7609>;
+pub type Message = heapless::Vec<u8, 20000>;
 pub type AppResult = core::result::Result<(), Error>;
 pub type ShortMessage = heapless::Vec<u8, 1024>;
 


### PR DESCRIPTION
Based on tag `v0.1.1-nitrokey.3`, which is the pinned reference in nitrokey-3-firmware Cargo.toml